### PR TITLE
Added additional check for options

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var flash = function(req, res, next) {
 };
 
 module.exports = function(options) {
-	if (options.locals) {
+	if (options!=null && options.locals) {
 		localsKey = options.locals;
 	}
 


### PR DESCRIPTION
There was [execption](http://stackoverflow.com/questions/37254646/expressjs-angularjs-error-after-implementing-req-flash) for: 

``` js
app.use(flash());
```

due to which one had to write like:

``` js
app.use(flash({}));
```

so resolved the issue with additional check, for options not being undefined.
Thanks.
