### PR TITLE
Only touch the session when we actually use the module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,18 +2,30 @@
 
 var localsKey;
 
-var _flash = function(container, key, message) {
-	if (typeof key === 'undefined' && typeof message === 'undefined') {
-		return container;
-	} else if (typeof message === 'undefined') {
-		return container[key];
+var _flash = function(session, key, message) {
+    if (typeof message !== 'undefined') {
+        if (typeof session._flash === 'undefined') {
+            session._flash = {};
+        }
+		session._flash[key] = message;
+        return;
+    }
+    
+    if (typeof session._flash === 'undefined') {
+        return null;
+    }
+
+	if (typeof key === 'undefined') {
+		return session._flash;
 	} else {
-		container[key] = message;
+		return session._flash[key];
 	}
 };
 
 var _clear = function(hijack, req, res) {
-	req.session._flash = {};
+    if (typeof req.session._flash !== 'undefined') {
+    	req.session._flash = {};
+    }
 
 	hijack.apply(res, Array.prototype.slice.call(arguments).slice(3));
 };
@@ -21,9 +33,7 @@ var _clear = function(hijack, req, res) {
 var flash = function(req, res, next) {
 	if (!req.session) throw new Error('Sessions are required.');
 
-	if (typeof req.session._flash === 'undefined') req.session._flash = {};
-
-	req.flash = _flash.bind(null, req.session._flash);
+	req.flash = _flash.bind(null, req.session);
 	res.render = _clear.bind(null, res.render, req, res);
 	res.send = _clear.bind(null, res.send, req, res);
 


### PR DESCRIPTION
At the moment just using the req-flash middleware is enough to make it modify the session. This is undesirable for two reasons:
 1) It wastes memory in the session store, since the session will now be committed at the end of the request.
 2) It sends a tracking cookie to the client that may require authorizations in some jurisdictions since it is not technically required.

This pull request only creates the session object when the user sends a flash message.