### PR TITLE
Update deprecated res.send to res.sendStatus

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var flash = function(req, res, next) {
 
 	req.flash = _flash.bind(null, req.session._flash);
 	res.render = _clear.bind(null, res.render, req, res);
-	res.send = _clear.bind(null, res.send, req, res);
+	res.sendStatus = _clear.bind(null, res.sendStatus, req, res);
 
 	if (localsKey) res.locals[localsKey] = req.flash();
 


### PR DESCRIPTION
Hi, I know this is old. But, I'm still using your lib in my project that is still running in production for 3 years now. A lot have changed since then in express. Would you update this deprecated function? And if this is updated, what will happen to other projects that's still using old express, will they break?